### PR TITLE
add sticky headers and optional height

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ pnpm add -D svelte-virtual@next
 | :------------- | :--------------------------- | :------------------------- | :-------: |
 | itemCount      | `number`                     |                            |     ✓     |
 | itemSize       | `number`                     |                            |     ✓     |
-| height         | `number`                     |                            |     ✓     |
+| height         | `number \| string`           | `"100%"`                   |           |
 | width          | `string`                     | `"100%"`                   |           |
+| stickyIndices  | `number[]`                   | `[]`                       |           |
 | overScan       | `number`                     | `1`                        |           |
 | marginLeft     | `number`                     | `0`                        |           |
 | marginTop      | `number`                     | `0`                        |           |

--- a/src/lib/list/List.svelte
+++ b/src/lib/list/List.svelte
@@ -32,8 +32,10 @@
 
 	export let itemCount: number;
 	export let itemSize: number;
-	export let height: number;
+	export let height: number | string = "100%";
 	export let width = "100%";
+
+    export let stickyIndexes: number[] = [];
 
 	export let overScan = 1;
 
@@ -152,7 +154,7 @@
 <div
 	style:position="relative"
 	style:overflow="auto"
-	style:height="{height}px"
+    style:height={typeof height === 'number' ? `${height}px` : height}
 	style:width
 	on:scroll={onScroll}
 	bind:this={list}
@@ -171,6 +173,22 @@
 		style:height={isVertical ? `${innerSize}px` : "100%"}
 		style:width={!isVertical ? `${innerSize}px` : "100%"}
 	>
+        {#if stickyIndexes.length}
+            {@const stickyIndex = Math.max(
+                ...stickyIndexes.filter((i) => i < (indexes?.[0] ?? 0))
+            )}
+            {#if stickyIndex >= 0}
+                <div
+                style:position="sticky"
+                style:top={isVertical ? `${marginTop}px` : '0px'}
+                style:left={isVertical ? '0px' : `${marginLeft}px`}
+                style:z-index="1"
+                >
+                <slot name="item" index={stickyIndex} />
+                </div>
+            {/if}
+        {/if}
+
 		{#each indexes as index (getKey(index))}
 			{@const style = getItemStyle(index)}
 

--- a/src/lib/list/List.svelte
+++ b/src/lib/list/List.svelte
@@ -35,7 +35,7 @@
 	export let height: number | string = "100%";
 	export let width = "100%";
 
-	export let stickyIndicies: number[] = [];
+	export let stickyIndices: number[] = [];
 
 	export let overScan = 1;
 
@@ -173,10 +173,8 @@
 		style:height={isVertical ? `${innerSize}px` : "100%"}
 		style:width={!isVertical ? `${innerSize}px` : "100%"}
 	>
-		{#if stickyIndicies.length}
-			{@const stickyIndex = Math.max(
-				...stickyIndicies.filter((i) => i < (indexes?.[0] ?? 0))
-			)}
+		{#if stickyIndices.length && indexes.length}
+			{@const stickyIndex = Math.max(...stickyIndices.filter((i) => i < indexes[0]))}
 			{#if stickyIndex >= 0}
 				<div
 					style:position="sticky"
@@ -184,7 +182,7 @@
 					style:left={isVertical ? "0px" : `${marginLeft}px`}
 					style:z-index="1"
 				>
-					<slot name="item" index={stickyIndex} />
+					<slot name="item" index={stickyIndex}>Missing template</slot>
 				</div>
 			{/if}
 		{/if}

--- a/src/lib/list/List.svelte
+++ b/src/lib/list/List.svelte
@@ -35,7 +35,7 @@
 	export let height: number | string = "100%";
 	export let width = "100%";
 
-    export let stickyIndexes: number[] = [];
+    export let stickyIndicies: number[] = [];
 
 	export let overScan = 1;
 
@@ -173,9 +173,9 @@
 		style:height={isVertical ? `${innerSize}px` : "100%"}
 		style:width={!isVertical ? `${innerSize}px` : "100%"}
 	>
-        {#if stickyIndexes.length}
+        {#if stickyIndicies.length}
             {@const stickyIndex = Math.max(
-                ...stickyIndexes.filter((i) => i < (indexes?.[0] ?? 0))
+                ...stickyIndicies.filter((i) => i < (indexes?.[0] ?? 0))
             )}
             {#if stickyIndex >= 0}
                 <div

--- a/src/lib/list/List.svelte
+++ b/src/lib/list/List.svelte
@@ -35,7 +35,7 @@
 	export let height: number | string = "100%";
 	export let width = "100%";
 
-    export let stickyIndicies: number[] = [];
+	export let stickyIndicies: number[] = [];
 
 	export let overScan = 1;
 
@@ -154,7 +154,7 @@
 <div
 	style:position="relative"
 	style:overflow="auto"
-    style:height={typeof height === 'number' ? `${height}px` : height}
+	style:height={typeof height === "number" ? `${height}px` : height}
 	style:width
 	on:scroll={onScroll}
 	bind:this={list}
@@ -173,21 +173,21 @@
 		style:height={isVertical ? `${innerSize}px` : "100%"}
 		style:width={!isVertical ? `${innerSize}px` : "100%"}
 	>
-        {#if stickyIndicies.length}
-            {@const stickyIndex = Math.max(
-                ...stickyIndicies.filter((i) => i < (indexes?.[0] ?? 0))
-            )}
-            {#if stickyIndex >= 0}
-                <div
-                style:position="sticky"
-                style:top={isVertical ? `${marginTop}px` : '0px'}
-                style:left={isVertical ? '0px' : `${marginLeft}px`}
-                style:z-index="1"
-                >
-                <slot name="item" index={stickyIndex} />
-                </div>
-            {/if}
-        {/if}
+		{#if stickyIndicies.length}
+			{@const stickyIndex = Math.max(
+				...stickyIndicies.filter((i) => i < (indexes?.[0] ?? 0))
+			)}
+			{#if stickyIndex >= 0}
+				<div
+					style:position="sticky"
+					style:top={isVertical ? `${marginTop}px` : "0px"}
+					style:left={isVertical ? "0px" : `${marginLeft}px`}
+					style:z-index="1"
+				>
+					<slot name="item" index={stickyIndex} />
+				</div>
+			{/if}
+		{/if}
 
 		{#each indexes as index (getKey(index))}
 			{@const style = getItemStyle(index)}


### PR DESCRIPTION
made some changes locally to fit my needs - thought it may be useful 🙂

- add the ability to set specific items as sticky
- change `height` to optional, defaulting to 100%